### PR TITLE
feat: ring alarm api

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .idea
 .vscode/
 *.code-workspace
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -184,6 +184,37 @@ printHealth( devices.chimes[0] );
 printHealth( devices.cameras[0] );
 ```
 
+Ring Alarm
+----------
+### Fetching Alarms
+```js
+const alarms = await ringApi.alarms();
+```
+`alarms` will be an array of alarms based on the locations you have set
+up in Ring.  Each location has it's own alarm that can be armed or disarmed,
+and used to interact with alarm devices in that location.
+### Arming/Disarming Alarms
+```js
+const alarm = alarms[0]
+alarm.disarm()
+alarm.armHome([/* optional array of zids for devices to bypass */])
+alarm.armAway([/* bypass zids */])
+const rooms = await alarm.getRooms() // array of rooms { id: number, name: string }
+```
+### Devices
+Once you have acquired the alarm for you desired location, you can start
+to interact with associated devices.
+```js
+const devices = await alarm.getDevices()
+const baseStation = devices.find(device => device.data.deviceType === 'hub.redsky')
+baseStation.setVolume(.75) // base station and keyboard support volume settings between 0 and 1
+console.log(baseStation.data) // object containing properties like zid, name, roomId, faulted, tamperStatus, etc.
+baseStation.onData.subscribe(data => {
+    // this will be called any time data is updated for this specific device
+})
+```
+
+
 debugging
 ---------
 

--- a/api-urls.js
+++ b/api-urls.js
@@ -95,6 +95,10 @@ function apiUrls( options ) {
                 },
 
             })
+        },
+
+        connections() {
+            return 'https://app.ring.com/api/v1/rs/connections'
         }
 
     })

--- a/examples/example-script.js
+++ b/examples/example-script.js
@@ -10,7 +10,7 @@ const colors = require( 'colors/safe' )
 const prompt = require( 'node-ask' ).prompt
 
 // edit here, or use the RING_USER and RING_PASSWORD environment variables:
-const username = undefined
+const email = undefined
 const password = undefined
 
 const main = async() => {
@@ -19,8 +19,8 @@ const main = async() => {
     try {
         ring = await ringApi({
             // we'll use the default options for this example. Maks sure you have the
-            // username and password as RING_USER or RING_PASSWORD or place them above
-            username, password
+            // email and password as RING_USER or RING_PASSWORD or place them above
+            email, password
         })
     } catch ( e ) {
         console.error( e )

--- a/get-alarms.js
+++ b/get-alarms.js
@@ -1,0 +1,234 @@
+'use strict'
+
+const io = require( 'socket.io-client' )
+const { Subject, BehaviorSubject } = require( 'rxjs' )
+const { filter, take, map, concatMap } = require( 'rxjs/operators' )
+const unique = require( 'lodash.uniq' )
+const delay = require( 'timeout-as-promise' )
+
+module.exports = bottle => bottle.service( 'getAlarms', getAlarms,
+    'restClient',
+    'apiUrls',
+    'getDevicesList'
+)
+
+const DeviceType = {
+    BaseStation: 'hub.redsky',
+    Keypad: 'security-keypad',
+    SecurityPanel: 'security-panel',
+    ContactSensor: 'sensor.contact',
+    MotionSensor: 'sensor.motion',
+    RangeExtender: 'range-extender.zwave',
+    ZigbeeAdapter: 'adapter.zigbee',
+    AccessCodeVault: 'access-code.vault',
+    AccessCode: 'access-code',
+}
+module.exports.AlarmDeviceType = DeviceType
+
+const deviceTypesWithVolume = [ DeviceType.BaseStation, DeviceType.Keypad ]
+
+function flattenDeviceData( data ) {
+    return Object.assign(
+        {},
+        data.general && data.general.v2,
+        data.device && data.device.v1
+    )
+}
+
+function getAlarms( restClient, apiUrls, getDeviceList ) {
+
+    class Device {
+        constructor( data, alarm ) {
+            const initialData = flattenDeviceData( data )
+
+            this.onData = new BehaviorSubject( initialData )
+            this.alarm = alarm
+
+            alarm.onDeviceDataUpdate
+                .pipe(
+                    filter( update => {
+                        return update.zid === this.data.zid
+                    })
+                )
+                .subscribe( update => {
+                    this.onData.next( Object.assign({}, this.data, update ))
+                })
+        }
+
+        get data() {
+            return this.onData.getValue()
+        }
+
+        get supportsVolume() {
+            return deviceTypesWithVolume.includes( this.data.deviceType )
+                && this.data.volume !== undefined
+        }
+
+
+        setVolume( volume ) {
+            if ( isNaN( volume ) || volume < 0 || volume > 1 ) {
+                throw new Error( 'Volume must be between 0 and 1' )
+            }
+
+            if ( !this.supportsVolume ) {
+                throw new Error( `Volume can only be set on ${deviceTypesWithVolume.join( ', ' )}` )
+            }
+
+            this.alarm.setDeviceInfo( this.data.zid, { device: { v1: { volume } } })
+        }
+
+        toString() {
+            return this.toJSON()
+        }
+
+        toJSON() {
+            return JSON.stringify({
+                data: this.data
+            }, null, 2 )
+        }
+    }
+
+    class Alarm {
+        constructor( locationId ) {
+            this.locationId = locationId
+            this.seq = 1
+            this.onMessage = new Subject()
+            this.onDataUpdate = new Subject()
+            this.onDeviceDataUpdate = this.onDataUpdate
+                .pipe(
+                    concatMap( message => message.body ),
+                    map( flattenDeviceData )
+                )
+        }
+
+        async createConnection() {
+            const connectionDetails = await restClient.oauthRequest( 'POST', apiUrls.connections(), {
+                accountId: this.locationId
+            })
+
+            const connection = io.connect( `wss://${connectionDetails.server}/?authcode=${connectionDetails.authCode}` )
+            const reconnect = () => {
+                if ( this.reconnecting && this.connectionPromise ) {
+                    return this.connectionPromise
+                }
+
+                this.reconnecting = true
+                connection.close()
+                return this.connectionPromise = delay( 1000 ).then(() => this.createConnection())
+            }
+
+            this.reconnecting = false
+            connection.on( 'DataUpdate', message => this.onDataUpdate.next( message ))
+            connection.on( 'message', message => this.onMessage.next( message ))
+            connection.on( 'error', reconnect )
+            return new Promise(( resolve, reject ) => {
+                connection.once( 'connect', () => resolve( connection ))
+                connection.once( 'error', reject )
+            }).catch( reconnect )
+        }
+
+        async getConnection() {
+            if ( this.connectionPromise ) {
+                return this.connectionPromise
+            }
+
+            return this.connectionPromise = this.createConnection()
+        }
+
+        async sendMessage( message ) {
+            const connection = await this.getConnection()
+            message.seq = this.seq++
+            connection.emit( 'message', message )
+        }
+
+        setDeviceInfo( zid, body ) {
+            return this.sendMessage({
+                msg: 'DeviceInfoSet',
+                datatype: 'DeviceInfoSetType',
+                body: [
+                    {
+                        zid,
+                        ...body
+                    }
+                ]
+            })
+        }
+
+        async setAlarmMode( alarmMode, bypassSensorZids ) {
+            const zid = await this.getSecurityPanelZid()
+            return this.setDeviceInfo( zid, {
+                command: {
+                    v1: [
+                        {
+                            commandType: 'security-panel.switch-mode',
+                            data: {
+                                mode: alarmMode,
+                                bypass: bypassSensorZids
+                            }
+                        }
+                    ]
+                }
+            })
+        }
+
+        getNextMessageOfType( type ) {
+            return this.onMessage.pipe(
+                filter( m => m.msg === type ),
+                map( m => m.body ),
+                take( 1 )
+            ).toPromise()
+        }
+
+        requestList( listType ) {
+            this.sendMessage({ msg: listType })
+            return this.getNextMessageOfType( listType )
+        }
+
+        async getDevices() {
+            const devices = await this.requestList( 'DeviceInfoDocGetList' )
+            return devices.map( data => new Device( data, this ))
+        }
+
+        getRoomList() {
+            return this.requestList( 'RoomGetList' )
+        }
+
+        async getSecurityPanelZid() {
+            if ( this.securityPanelZid ) {
+                return this.securityPanelZid
+            }
+
+            const devices = await this.getDevices()
+            const securityPanel = devices.find( device => {
+                return device.data.deviceType === DeviceType.SecurityPanel
+            })
+
+            if ( !securityPanel ) {
+                throw new Error( `Could not find a security panel for location ${this.locationId}` )
+            }
+
+            return this.securityPanelZid = securityPanel.data.zid
+        }
+
+        disarm() {
+            return this.setAlarmMode( 'none' )
+        }
+
+        armHome( bypassSensorZids ) {
+            return this.setAlarmMode( 'some', bypassSensorZids )
+        }
+
+        armAway( bypassSensorZids ) {
+            return this.setAlarmMode( 'all', bypassSensorZids )
+        }
+    }
+
+    return async() => {
+        const devices = await getDeviceList()
+        const baseStations = devices.baseStations
+        const locationIds = baseStations.map( baseStation => baseStation.location_id )
+
+        return unique( locationIds ).map( locationId => new Alarm( locationId ))
+    }
+}
+

--- a/get-alarms.js
+++ b/get-alarms.js
@@ -154,7 +154,7 @@ function getAlarms( restClient, apiUrls, getDeviceList, logger ) {
 
             this.reconnecting = false
             connection.on( 'DataUpdate', message => {
-                if ( message.type === 'HubDisconnectionEventType' ) {
+                if ( message.datatype === 'HubDisconnectionEventType' ) {
                     logger( 'Alarm connection told to reconnect' )
                     return reconnect()
                 }

--- a/get-alarms.js
+++ b/get-alarms.js
@@ -96,7 +96,9 @@ function getAlarms( restClient, apiUrls, getDeviceList ) {
             this.onDataUpdate = new Subject()
             this.onDeviceDataUpdate = this.onDataUpdate
                 .pipe(
-                    filter( message => Boolean( message.body )),
+                    filter( message => {
+                        return message.datatype === 'DeviceInfoDocType' && Boolean( message.body )
+                    }),
                     concatMap( message => message.body ),
                     map( flattenDeviceData )
                 )

--- a/get-alarms.js
+++ b/get-alarms.js
@@ -23,6 +23,9 @@ const DeviceType = {
         ZigbeeAdapter: 'adapter.zigbee',
         AccessCodeVault: 'access-code.vault',
         AccessCode: 'access-code',
+        SmokeAlarm: 'alarm.smoke',
+        CoAlarm: 'alarm.co',
+        SmokeCoListener: 'listener.smoke-co',
     },
     deviceListMessageType = 'DeviceInfoDocGetList'
 

--- a/get-alarms.js
+++ b/get-alarms.js
@@ -96,6 +96,7 @@ function getAlarms( restClient, apiUrls, getDeviceList ) {
             this.onDataUpdate = new Subject()
             this.onDeviceDataUpdate = this.onDataUpdate
                 .pipe(
+                    filter( message => Boolean( message.body )),
                     concatMap( message => message.body ),
                     map( flattenDeviceData )
                 )

--- a/main.d.ts
+++ b/main.d.ts
@@ -43,6 +43,7 @@ declare namespace RingApi {
     }
 
     interface AlarmDevice {
+        zid: string
         onData: Observable<AlarmDeviceData>
         data: AlarmDeviceData
         alarm: Alarm
@@ -57,7 +58,10 @@ declare namespace RingApi {
         onDeviceDataUpdate: Observable<AlarmDeviceData>
 
         getDevices (): Promise<AlarmDevice[]>
-        requestList <T = any> (listType: string): Promise<T[]>
+        onDevices (): Observable<AlarmDevice[]>
+        requestList (listType: string): void
+        getList <T = any> (listType: string): Promise<T[]>
+        getNextMessageOfType <T = any> (type: string): Promise<T>
         sendMessage (message: any): Promise<void>
         setDeviceInfo (zid: string, body: any): Promise<void>
         getRoomList (): Promise<{ id: number, name: string }>

--- a/main.d.ts
+++ b/main.d.ts
@@ -34,6 +34,12 @@ declare namespace RingApi {
         roomId?: number
         volume?: number
         mode?: 'all' | 'some' | 'none'
+        alarmInfo?: {
+            state: 'burglar-alarm' | 'entry-delay'
+            faultedDevices?: string[]
+            timestamp?: number
+            uuid?: string
+        }
     }
 
     interface AlarmDevice {

--- a/main.d.ts
+++ b/main.d.ts
@@ -1,0 +1,69 @@
+import { Observable } from 'rxjs'
+
+declare namespace RingApi {
+    interface Config {
+        email: string
+        password: string
+        poll?: boolean
+        serverRoot?: string
+    }
+
+    enum AlarmDeviceType {
+        BaseStation = 'hub.redsky',
+        Keypad = 'security-keypad',
+        SecurityPanel = 'security-panel',
+        ContactSensor = 'sensor.contact',
+        MotionSensor = 'sensor.motion',
+        RangeExtender = 'range-extender.zwave',
+        ZigbeeAdapter = 'adapter.zigbee',
+        AccessCodeVault = 'access-code.vault',
+        AccessCode = 'access-code',
+    }
+
+    interface AlarmDeviceData {
+        zid: string
+        name: string
+        deviceType: AlarmDeviceType
+        batteryLevel?: number
+        batteryStatus: 'full' | 'ok' | 'low' | 'none' | 'charging'
+        batteryBackup?: 'charged' | 'charging'
+        manufacturerName?: string
+        serialNumber?: string
+        tamperStatus: 'ok' | 'tamper'
+        faulted?: boolean
+        roomId?: number
+        volume?: number
+        mode?: 'all' | 'some' | 'none'
+    }
+
+    interface AlarmDevice {
+        onData: Observable<AlarmDeviceData>
+        data: AlarmDeviceData
+        alarm: Alarm
+
+        supportsVolume: boolean
+        setVolume (volume: number): void
+    }
+
+    interface Alarm {
+        locationId: string
+        onDataUpdate: Observable<any>
+        onDeviceDataUpdate: Observable<AlarmDeviceData>
+
+        getDevices (): Promise<AlarmDevice[]>
+        requestList <T = any> (listType: string): Promise<T[]>
+        sendMessage (message: any): Promise<void>
+        setDeviceInfo (zid: string, body: any): Promise<void>
+        getRoomList (): Promise<{ id: number, name: string }>
+        disarm (): Promise<void>
+        armHome (bypassSensorZids?: string[]): Promise<void>
+        armAway (bypassSensorZids?: string[]): Promise<void>
+    }
+
+    interface Api {
+        alarms (): Promise<Alarm[]>
+    }
+}
+
+declare function RingApi (config: RingApi.Config): Promise<RingApi.Api>
+export = RingApi

--- a/main.d.ts
+++ b/main.d.ts
@@ -31,6 +31,7 @@ declare namespace RingApi {
         serialNumber?: string
         tamperStatus: 'ok' | 'tamper'
         faulted?: boolean
+        locked?: 'jammed' | 'locked' | 'unlocked' | 'unknown'
         roomId?: number
         volume?: number
         mode?: 'all' | 'some' | 'none'

--- a/main.d.ts
+++ b/main.d.ts
@@ -18,6 +18,9 @@ declare namespace RingApi {
         ZigbeeAdapter = 'adapter.zigbee',
         AccessCodeVault = 'access-code.vault',
         AccessCode = 'access-code',
+        SmokeAlarm = 'alarm.smoke',
+        CoAlarm = 'alarm.co',
+        SmokeCoListener = 'listener.smoke-co',
     }
 
     interface AlarmDeviceData {
@@ -36,11 +39,14 @@ declare namespace RingApi {
         volume?: number
         mode?: 'all' | 'some' | 'none'
         alarmInfo?: {
-            state: 'burglar-alarm' | 'entry-delay'
+            state: 'burglar-alarm' | 'entry-delay' | 'fire-alarm' | 'co-alarm' | 'panic' | 'user-verified-co-or-fire-alarm' | 'user-verified-burglar-alarm'
             faultedDevices?: string[]
             timestamp?: number
             uuid?: string
         }
+        alarmStatus?: 'active'
+        co?: { alarmStatus?: 'active' }
+        smoke?: { alarmStatus?: 'active' }
     }
 
     interface AlarmDevice {

--- a/main.js
+++ b/main.js
@@ -33,8 +33,12 @@ module.exports = async({
         throw propagatedError( 'ring gave a seemingly valid authentication/authorisation, but the failed', e )
     }
 
-    container.pollForDings.start()
+    if ( poll ) {
+        container.pollForDings.start()
+    }
 
     return container.api
 }
+
+module.exports.AlarmDeviceType = require( './get-alarms' ).AlarmDeviceType
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-api",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -122,6 +122,11 @@
         "acorn": "^5.0.3"
       }
     },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
     "ajv": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
@@ -182,11 +187,21 @@
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "axios": {
       "version": "0.18.0",
@@ -252,16 +267,39 @@
       "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
       "dev": true
     },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
     "bignumber.js": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+    },
+    "blob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "bottlejs": {
       "version": "1.7.1",
@@ -286,6 +324,11 @@
       "requires": {
         "callsites": "^0.2.0"
       }
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "callsites": {
       "version": "0.2.0",
@@ -371,6 +414,21 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
       "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw=="
     },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -445,6 +503,36 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "engine.io-client": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "~3.3.1",
+        "xmlhttprequest-ssl": "~1.5.4",
+        "yeast": "0.1.2"
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary2": "~1.0.2"
       }
     },
     "es-abstract": {
@@ -761,6 +849,19 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "has-binary2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "requires": {
+        "isarray": "2.0.1"
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+    },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -793,6 +894,11 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
       "version": "1.0.6",
@@ -829,6 +935,17 @@
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "5.5.12",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+          "dev": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        }
       }
     },
     "invariant": {
@@ -913,6 +1030,11 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
+    },
+    "isarray": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+      "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1033,6 +1155,11 @@
       "resolved": "https://registry.npmjs.org/lodash.mapkeys/-/lodash.mapkeys-4.6.0.tgz",
       "integrity": "sha1-3yz6Ix18V8eorQA6va1dc9PqUZU="
     },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1107,6 +1234,11 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -1150,6 +1282,22 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1280,13 +1428,17 @@
       }
     },
     "rxjs": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
-      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
-      "dev": true,
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "^1.9.0"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -1337,6 +1489,37 @@
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "socket.io-client": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+      "requires": {
+        "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "~3.2.0",
+        "to-array": "0.1.4"
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
       }
     },
     "source-map": {
@@ -1454,6 +1637,11 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -1466,6 +1654,11 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -1474,6 +1667,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "uri-js": {
       "version": "4.2.2",
@@ -1513,6 +1711,26 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "requires": {
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
+      }
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.7",
   "description": "Unofficial API for ring doorbells and other devices",
   "main": "main.js",
+  "typings": "main.d.ts",
   "dependencies": {
     "axios": "^0.18.0",
     "bottlejs": "^1.7.1",
@@ -17,7 +18,10 @@
     "lodash.flatten": "^4.4.0",
     "lodash.isobject": "^3.0.2",
     "lodash.mapkeys": "^4.6.0",
+    "lodash.uniq": "^4.5.0",
+    "rxjs": "^6.3.3",
     "sip.js": "^0.11.3",
+    "socket.io-client": "^2.1.1",
     "time-constants": "^1.0.2",
     "timeout-as-promise": "^1.0.0"
   },

--- a/rest-client.js
+++ b/rest-client.js
@@ -101,6 +101,9 @@ function restClient( apiUrls, { email, password }, logger ) {
             throw propagatedError( `could not get auth token for user ${email}`, requestError )
         }
 
+        // delay to allow ring api time to store the new auth token
+        await delay( 1500 )
+
         logger( 'got auth token', colors.green( authToken ))
 
         return authToken
@@ -133,6 +136,9 @@ function restClient( apiUrls, { email, password }, logger ) {
         } catch ( requestError ) {
             throw propagatedError( `could not get a session token given auth token ${authToken}`, requestError )
         }
+
+        // delay to allow ring api time to store the new session token
+        await delay( 1500 )
 
         logger( 'got session token', colors.green( sessionToken ))
 

--- a/top-level-api.js
+++ b/top-level-api.js
@@ -6,14 +6,16 @@ module.exports = bottle => {
         'getDevicesList',
         'getHistoryList',
         'getActiveDings',
+        'getAlarms',
         'events'
     )
 
-    function api( getDevicesList, getHistoryList, getActiveDings, events ) {
+    function api( getDevicesList, getHistoryList, getActiveDings, getAlarms, events ) {
         return {
             devices: getDevicesList,
             history: getHistoryList,
             activeDings: getActiveDings,
+            alarms: getAlarms,
             events
         }
     }

--- a/wire-up.js
+++ b/wire-up.js
@@ -13,6 +13,7 @@ module.exports = options => {
     require( './get-history-list' )( bottle )
     require( './get-live-stream' )( bottle )
     require( './get-devices-list' )( bottle )
+    require( './get-alarms' )( bottle )
     require( './poll-for-dings' )( bottle )
     require( './get-active-dings' )( bottle )
 


### PR DESCRIPTION
## Ring Alarm
 - Get alarms from all ring locations
 - Get devices for each alarm
 - Arm/disarm alarm with optional bypass of specific sensors
 - Subscribe to data updates on individual devices
 - Change volume on base station and keypad
 - Flattened data structure for returned device data.  Original format from ring is cumbersome to interact with

## Other Enhancements
 - Editorconfig consisten with existing code style
 - Re-fetching of auth token if it appears to have expired
 - OAuth requests using `Bearer token` auth header
 - Retrying api calls if the endpoint is unreachable (for cases where internet connection is interrupted)
 - Typescript `.d.ts` file added.  Currently only contains types for my alarm additions

Closes #8 

Sorry for the long delay on this, haven't had much free time lately.  Looks like @mrose17 has a different implementation based on doorbot over at https://github.com/homespun/ring-alarm now.  Personally, I think your base library setup is cleaner and more modern so I think it's still worth adding alarm functionality here.  For anyone interested in a homebridge plugin, I have one ready to go that I will be publishing in the next couple days (probably waiting until this PR is merged).